### PR TITLE
Fix link

### DIFF
--- a/index.md
+++ b/index.md
@@ -61,7 +61,7 @@ _While you're in town, pick up excellent cocktail supplies at [The Boston Shaker
 ### Berlin
 
 * [Pauly Saal](http://paulysaal.com/) - Creative mix, classic vibe 🍴
-* [Lebensstern](http://www.lebensstern-berlin.de/) - Library of liquor 
+* [Lebensstern](http://www.lebens-stern.de/) - Library of liquor 
 
 ## Middle East
 


### PR DESCRIPTION
Currently, this links to a site for discount PC speakers, which I don't *think* is an elaborate speakeasy front.